### PR TITLE
HCD-4: Implement start/stop Job functionality for the JobView

### DIFF
--- a/cmd/damon/main.go
+++ b/cmd/damon/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hcjulz/damon/nomad"
 	"github.com/hcjulz/damon/state"
+	"github.com/hcjulz/damon/styles"
 	"github.com/hcjulz/damon/view"
 	"github.com/hcjulz/damon/watcher"
 
@@ -62,6 +63,12 @@ func main() {
 	errorComp := component.NewError()
 	info := component.NewInfo()
 	failure := component.NewInfo()
+	confirm := component.NewModal(
+		"confirm",
+		"confirm",
+		[]string{"cancel", "confirm"},
+		styles.TcellColorAttention,
+	)
 
 	components := &view.Components{
 		ClusterInfo:     clusterInfo,
@@ -79,6 +86,7 @@ func main() {
 		Info:            info,
 		Failure:         failure,
 		LogSearch:       logSearch,
+		Confirm:         confirm,
 	}
 
 	watcher := watcher.NewWatcher(state, nomadClient, refreshIntervalDefault)

--- a/component/commands.go
+++ b/component/commands.go
@@ -24,6 +24,7 @@ var (
 		fmt.Sprintf("\n%sJob Commands:", styles.HighlightSecondaryTag),
 		fmt.Sprintf("%s<Enter>%s to display allocations", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s<t>%s to display TaskGroups for a Job", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%s<ctrl-s>%s start/stop a Job", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s</>%s apply filter", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 

--- a/component/component.go
+++ b/component/component.go
@@ -69,6 +69,7 @@ type Modal interface {
 	Primitive
 	SetDoneFunc(handler func(buttonIndex int, buttonLabel string))
 	SetText(text string)
+	SetFocus(index int)
 	Container() tview.Primitive
 }
 

--- a/component/componentfakes/fake_modal.go
+++ b/component/componentfakes/fake_modal.go
@@ -34,6 +34,11 @@ type FakeModal struct {
 	setDoneFuncArgsForCall []struct {
 		arg1 func(buttonIndex int, buttonLabel string)
 	}
+	SetFocusStub        func(int)
+	setFocusMutex       sync.RWMutex
+	setFocusArgsForCall []struct {
+		arg1 int
+	}
 	SetTextStub        func(string)
 	setTextMutex       sync.RWMutex
 	setTextArgsForCall []struct {
@@ -181,6 +186,38 @@ func (fake *FakeModal) SetDoneFuncArgsForCall(i int) func(buttonIndex int, butto
 	return argsForCall.arg1
 }
 
+func (fake *FakeModal) SetFocus(arg1 int) {
+	fake.setFocusMutex.Lock()
+	fake.setFocusArgsForCall = append(fake.setFocusArgsForCall, struct {
+		arg1 int
+	}{arg1})
+	stub := fake.SetFocusStub
+	fake.recordInvocation("SetFocus", []interface{}{arg1})
+	fake.setFocusMutex.Unlock()
+	if stub != nil {
+		fake.SetFocusStub(arg1)
+	}
+}
+
+func (fake *FakeModal) SetFocusCallCount() int {
+	fake.setFocusMutex.RLock()
+	defer fake.setFocusMutex.RUnlock()
+	return len(fake.setFocusArgsForCall)
+}
+
+func (fake *FakeModal) SetFocusCalls(stub func(int)) {
+	fake.setFocusMutex.Lock()
+	defer fake.setFocusMutex.Unlock()
+	fake.SetFocusStub = stub
+}
+
+func (fake *FakeModal) SetFocusArgsForCall(i int) int {
+	fake.setFocusMutex.RLock()
+	defer fake.setFocusMutex.RUnlock()
+	argsForCall := fake.setFocusArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeModal) SetText(arg1 string) {
 	fake.setTextMutex.Lock()
 	fake.setTextArgsForCall = append(fake.setTextArgsForCall, struct {
@@ -222,6 +259,8 @@ func (fake *FakeModal) Invocations() map[string][][]interface{} {
 	defer fake.primitiveMutex.RUnlock()
 	fake.setDoneFuncMutex.RLock()
 	defer fake.setDoneFuncMutex.RUnlock()
+	fake.setFocusMutex.RLock()
+	defer fake.setFocusMutex.RUnlock()
 	fake.setTextMutex.RLock()
 	defer fake.setTextMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/component/job_table.go
+++ b/component/job_table.go
@@ -88,6 +88,11 @@ func (j *JobTable) Render() error {
 	return nil
 }
 
+func (j *JobTable) GetIDForSelection() string {
+	row, _ := j.Table.GetSelection()
+	return j.Table.GetCellContent(row, 0)
+}
+
 func (j *JobTable) validate() error {
 	if j.Props.SelectJob == nil || j.Props.HandleNoResources == nil {
 		return ErrComponentPropsNotSet

--- a/component/modal.go
+++ b/component/modal.go
@@ -1,0 +1,49 @@
+package component
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	primitive "github.com/hcjulz/damon/primitives"
+)
+
+type GenericModal struct {
+	Modal Modal
+	Props *ModalProps
+	pages *tview.Pages
+}
+
+type ModalProps struct {
+	ID   string
+	Done DoneModalFunc
+}
+
+func NewModal(id, title string, buttons []string, c tcell.Color) *GenericModal {
+	modal := primitive.NewModal(title, buttons, c)
+
+	return &GenericModal{
+		Modal: modal,
+		Props: &ModalProps{ID: id},
+	}
+}
+
+func (m *GenericModal) Render(msg string) error {
+	if m.Props.Done == nil {
+		return ErrComponentPropsNotSet
+	}
+
+	if m.pages == nil {
+		return ErrComponentNotBound
+	}
+
+	m.Modal.SetFocus(0)
+	m.Modal.SetDoneFunc(m.Props.Done)
+	m.Modal.SetText(msg)
+	m.pages.AddPage(m.Props.ID, m.Modal.Container(), true, true)
+
+	return nil
+}
+
+func (m *GenericModal) Bind(pages *tview.Pages) {
+	m.pages = pages
+}

--- a/component/modal_test.go
+++ b/component/modal_test.go
@@ -1,0 +1,76 @@
+package component_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hcjulz/damon/component"
+	"github.com/hcjulz/damon/component/componentfakes"
+)
+
+func TestModal_Happy(t *testing.T) {
+	r := require.New(t)
+
+	e := component.NewModal("test", "test", []string{"OK"}, tcell.ColorWhite)
+
+	modal := &componentfakes.FakeModal{}
+	e.Modal = modal
+
+	var doneCalled bool
+	e.Props.Done = func(buttonIndex int, buttonLabel string) {
+		doneCalled = true
+	}
+
+	pages := tview.NewPages()
+	e.Bind(pages)
+
+	err := e.Render("test")
+	r.NoError(err)
+
+	actualDone := modal.SetDoneFuncArgsForCall(0)
+	text := modal.SetTextArgsForCall(0)
+
+	actualDone(0, "OK")
+
+	r.True(doneCalled)
+	r.Equal(text, "test")
+}
+
+func TestModal_Sad(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("When the component isn't bound", func(t *testing.T) {
+		e := component.NewInfo()
+
+		e.Props.Done = func(buttonIndex int, buttonLabel string) {}
+
+		err := e.Render("test")
+		r.Error(err)
+
+		// It provides the correct error message
+		r.EqualError(err, "component not bound")
+
+		// It is the correct error
+		r.True(errors.Is(err, component.ErrComponentNotBound))
+	})
+
+	t.Run("When DoneFunc is not set", func(t *testing.T) {
+		e := component.NewInfo()
+
+		pages := tview.NewPages()
+		e.Bind(pages)
+
+		err := e.Render("error")
+		r.Error(err)
+
+		// It provides the correct error message
+		r.EqualError(err, "component properties not set")
+
+		// It is the correct error
+		r.True(errors.Is(err, component.ErrComponentPropsNotSet))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/cronexpr v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/nomad/api v0.0.0-20210709134434-c4e0355775f3
+	github.com/hashicorp/nomad/api v0.0.0-20210804153318-c67b69bd0cc6
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/rivo/tview v0.0.0-20210427112837-09cec83b1732

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/nomad/api v0.0.0-20210709134434-c4e0355775f3 h1:BOBoGSnaNSLtMVDjwMbH9yW40COa8QLOr16dc0IKBns=
 github.com/hashicorp/nomad/api v0.0.0-20210709134434-c4e0355775f3/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
+github.com/hashicorp/nomad/api v0.0.0-20210804153318-c67b69bd0cc6 h1:kqVyRGdvPCQ3pIgZBvu7ISJZCELxkgSg5qrPO893sLc=
+github.com/hashicorp/nomad/api v0.0.0-20210804153318-c67b69bd0cc6/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/nomad/client.go
+++ b/nomad/client.go
@@ -53,6 +53,7 @@ type SearchOptions struct {
 }
 
 type Nomad struct {
+	nomad         *api.Client
 	Client        Client
 	EventsClient  EventsClient
 	JobClient     JobClient
@@ -81,6 +82,7 @@ func Default(n *Nomad) error {
 	}
 	// client.Allocations().Info(allocID string, q *api.QueryOptions)
 
+	n.nomad = client
 	n.Client = client
 	n.EventsClient = client.EventStream()
 	n.JobClient = client.Jobs()

--- a/nomad/jobs.go
+++ b/nomad/jobs.go
@@ -51,8 +51,10 @@ func (n *Nomad) GetJob(jobID string) (*api.Job, error) {
 }
 
 func (n *Nomad) StartJob(job *api.Job) error {
-	_, _, err := n.JobClient.Register(job, nil)
+	stop := false
+	job.Stop = &stop
 
+	_, _, err := n.JobClient.Register(job, nil)
 	return err
 }
 

--- a/primitives/modal.go
+++ b/primitives/modal.go
@@ -15,6 +15,7 @@ func NewModal(title string, buttons []string, c tcell.Color) *Modal {
 	m.SetTitle(title)
 	m.SetTitleAlign(tview.AlignCenter)
 	m.SetBackgroundColor(c)
+	m.SetTextColor(tcell.ColorBlack)
 	m.AddButtons(buttons)
 
 	f := tview.NewFlex().
@@ -37,6 +38,10 @@ func (m *Modal) SetDoneFunc(handler func(buttonIndex int, buttonLabel string)) {
 
 func (m *Modal) SetText(text string) {
 	m.primitive.SetText(text)
+}
+
+func (m *Modal) SetFocus(index int) {
+	m.primitive.SetFocus(index)
 }
 
 func (m *Modal) Container() tview.Primitive {

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -18,19 +18,21 @@ var (
 	StandardColorHex      = "#00b57c"
 	ColorActiveHex        = "#b3f1ff"
 	ColorWhiteHex         = "#ffffff"
-	ColorLightGrey        = "#cccccc"
+	ColorLightGreyHex     = "#cccccc"
 	ColorModalInfoHex     = "#61877f"
+	ColorAttentionHex     = "#d98b6a"
 
 	StandardColorTag      = fmt.Sprintf("[%s]", StandardColorHex)
 	HighlightPrimaryTag   = fmt.Sprintf("[%s]", HighlightPrimaryHex)
 	HighlightSecondaryTag = fmt.Sprintf("[%s]", HighlightSecondaryHex)
 	ColorActiveTag        = fmt.Sprintf("[%s]", ColorActiveHex)
 	ColorWhiteTag         = fmt.Sprintf("[%s]", ColorWhiteHex)
-	ColorLighGreyTag      = fmt.Sprintf("[%s]", ColorLightGrey)
+	ColorLighGreyTag      = fmt.Sprintf("[%s]", ColorLightGreyHex)
 
 	TcellColorHighlighPrimary   = tcell.GetColor(HighlightPrimaryHex)
 	TcellColorHighlighSecondary = tcell.GetColor(HighlightSecondaryHex)
 	TcellColorStandard          = tcell.GetColor(StandardColorHex)
 	TcellColorActive            = tcell.GetColor(ColorActiveHex)
 	TcellColorModalInfo         = tcell.GetColor(ColorModalInfoHex)
+	TcellColorAttention         = tcell.GetColor(ColorAttentionHex)
 )

--- a/view/handler.go
+++ b/view/handler.go
@@ -18,6 +18,13 @@ func (v *View) handleNoResources(text string, args ...interface{}) {
 	v.Layout.Body.AddItem(info, 0, 1, false)
 }
 
+func (v *View) err(err error, msg string) {
+	if err != nil {
+		fmt.Sprintf("%s: %s", msg, err.Error())
+		v.handleError(msg)
+	}
+}
+
 func (v *View) handleError(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	v.components.Failure.Render(msg)

--- a/view/init.go
+++ b/view/init.go
@@ -142,6 +142,8 @@ func (v *View) Init(version string) {
 		v.GoBack()
 	}
 
+	v.components.Confirm.Bind(v.Layout.Pages)
+
 	v.Watcher.SubscribeHandler(models.HandleError, v.handleError)
 	v.Watcher.SubscribeHandler(models.HandleFatal, v.handleFatal)
 

--- a/view/inputs.go
+++ b/view/inputs.go
@@ -68,40 +68,6 @@ func (v *View) mainCommands(event *tcell.EventKey) *tcell.EventKey {
 	return event
 }
 
-func (v *View) inputJobs(event *tcell.EventKey) *tcell.EventKey {
-	if event == nil {
-		return event
-	}
-
-	switch event.Key() {
-	case tcell.KeyRune:
-		switch event.Rune() {
-		case 't':
-			if v.Layout.Footer.HasFocus() || v.components.Search.InputField.Primitive().HasFocus() {
-				return event
-			}
-
-			row, _ := v.components.JobTable.Table.GetSelection()
-			jobID := v.components.JobTable.Table.GetCellContent(row, 0)
-			v.TaskGroups(jobID)
-
-		case '/':
-			if !v.Layout.Footer.HasFocus() {
-				if !v.state.Toggle.Search {
-					v.state.Toggle.Search = true
-					v.Search()
-				} else {
-					v.Layout.Container.SetFocus(v.components.Search.InputField.Primitive())
-				}
-				return nil
-			}
-		}
-
-	}
-
-	return event
-}
-
 func (v *View) inputAllocs(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
 	case tcell.KeyCtrlE:
@@ -119,8 +85,6 @@ func (v *View) InputLogs(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
 	case tcell.KeyEsc, tcell.KeyCtrlO, tcell.KeyEnter:
 		if v.components.LogStream.TextView.Primitive().HasFocus() {
-			// close(v.state.Channels.CancelLogStream)
-			// v.Layout.Container.SetInputCapture(v.InputJobs)
 			v.GoBack()
 			return nil
 		}

--- a/view/view.go
+++ b/view/view.go
@@ -64,6 +64,7 @@ type Components struct {
 	LogStream       *component.Logger
 	LogSearch       *component.SearchField
 	Search          *component.SearchField
+	Confirm         *component.GenericModal
 }
 
 func New(components *Components, watcher Watcher, client Client, state *state.State) *View {
@@ -145,4 +146,8 @@ func (v *View) addToHistory(ns string, topic api.Topic, update func()) {
 		index := getNamespaceNameIndex(ns, v.state.Namespaces)
 		v.state.Elements.DropDownNamespace.SetCurrentOption(index)
 	})
+}
+
+func (v *View) viewSwitch() {
+	v.resetSearch()
 }


### PR DESCRIPTION
### What is this about?

-> [#4]

This PR adds the ability to start/stop jobs from the Jobs View using the keybinding `ctrl-s`.

### What does it do?

This PR adds a new Generic Modal component that is used to create a "Confirmation Modal". The confirmation modal is used to let the user confirm the action of start or stopping a Job before the action is executed. Additionally, it adds a a new "Attention" colour to the `styles` package.

![image](https://user-images.githubusercontent.com/82210389/128600944-6d042f1d-a032-4bd5-b112-4ff3fefde95b.png)
