### PR TITLE
HCD-6: Add a task status summary to the job table

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -15,6 +15,7 @@ const (
 	LabelNamespace         = "Namespace"
 	LabelStatus            = "Status"
 	LabelStatusDescription = "Description"
+	LabelStatusSummary     = "Summary"
 	LabelDescription       = "Description"
 	LabelCount             = "Count"
 	LabelSubmitTime        = "SubmitTime"

--- a/component/job_table.go
+++ b/component/job_table.go
@@ -23,6 +23,7 @@ var (
 		LabelType,
 		LabelNamespace,
 		LabelStatus,
+		LabelStatusSummary,
 		LabelSubmitTime,
 		LabelUptime,
 	}
@@ -123,22 +124,28 @@ func (j *JobTable) renderRows() {
 			job.Type,
 			job.Namespace,
 			job.Status,
+			fmt.Sprintf("%d/%d", job.StatusSummary.Running, job.StatusSummary.Total),
 			job.SubmitTime.Format(time.RFC3339),
 			formatTimeSince(time.Since(job.SubmitTime)),
 		}
 
 		index := i + 1
 
-		c := j.cellColor(job.Status, job.Type)
+		c := j.cellColor(job.Status, job.Type, job.StatusSummary)
 
 		j.Table.RenderRow(row, index, c)
 	}
 }
 
-func (j *JobTable) cellColor(status, typ string) tcell.Color {
+func (j *JobTable) cellColor(status, typ string, summary models.Summary) tcell.Color {
 	c := tcell.ColorWhite
 
 	switch status {
+	case models.StatusRunning:
+		if summary.Total != summary.Running &&
+			typ == models.TypeService {
+			c = styles.TcellColorAttention
+		}
 	case models.StatusPending:
 		c = tcell.ColorYellow
 	case models.StatusDead, models.StatusFailed:

--- a/component/job_table_test.go
+++ b/component/job_table_test.go
@@ -34,6 +34,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Namespace:         "space",
 				Status:            "running",
 				StatusDescription: "fine",
+				StatusSummary:     models.Summary{Total: 2, Running: 2},
 				SubmitTime:        now,
 			},
 			{
@@ -43,6 +44,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Namespace:         "space",
 				Status:            "pending",
 				StatusDescription: "fine",
+				StatusSummary:     models.Summary{Total: 2, Running: 2},
 				SubmitTime:        now,
 			},
 			{
@@ -52,6 +54,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Namespace:         "space",
 				Status:            "dead",
 				StatusDescription: "fine",
+				StatusSummary:     models.Summary{Total: 1, Running: 1},
 				SubmitTime:        now,
 			},
 			{
@@ -60,6 +63,17 @@ func TestJobTable_Happy(t *testing.T) {
 				Type:              "batch",
 				Namespace:         "space",
 				Status:            "dead",
+				StatusSummary:     models.Summary{Total: 1, Running: 0},
+				StatusDescription: "fine",
+				SubmitTime:        now,
+			},
+			{
+				ID:                "yo",
+				Name:              "venus",
+				Type:              "service",
+				Namespace:         "space",
+				Status:            "running",
+				StatusSummary:     models.Summary{Total: 1, Running: 0},
 				StatusDescription: "fine",
 				SubmitTime:        now,
 			},
@@ -85,35 +99,40 @@ func TestJobTable_Happy(t *testing.T) {
 
 		// It renders the correct number of rows
 		renderRowCallCount := fakeTable.RenderRowCallCount()
-		r.Equal(renderRowCallCount, 4)
+		r.Equal(renderRowCallCount, 5)
 
 		row1, index1, c1 := fakeTable.RenderRowArgsForCall(0)
 		row2, index2, c2 := fakeTable.RenderRowArgsForCall(1)
 		row3, index3, c3 := fakeTable.RenderRowArgsForCall(2)
 		row4, index4, c4 := fakeTable.RenderRowArgsForCall(3)
+		row5, index5, c5 := fakeTable.RenderRowArgsForCall(4)
 
-		expectedRow1 := []string{"ichi", "saturn", "service", "space", "running", now.Format(time.RFC3339), "0s"}
-		expectedRow2 := []string{"ni", "jupiter", "service", "space", "pending", now.Format(time.RFC3339), "0s"}
-		expectedRow3 := []string{"san", "neptun", "service", "space", "dead", now.Format(time.RFC3339), "0s"}
-		expectedRow4 := []string{"chi", "mars", "batch", "space", "dead", now.Format(time.RFC3339), "0s"}
+		expectedRow1 := []string{"ichi", "saturn", "service", "space", "running", "2/2", now.Format(time.RFC3339), "0s"}
+		expectedRow2 := []string{"ni", "jupiter", "service", "space", "pending", "2/2", now.Format(time.RFC3339), "0s"}
+		expectedRow3 := []string{"san", "neptun", "service", "space", "dead", "1/1", now.Format(time.RFC3339), "0s"}
+		expectedRow4 := []string{"chi", "mars", "batch", "space", "dead", "0/1", now.Format(time.RFC3339), "0s"}
+		expectedRow5 := []string{"yo", "venus", "service", "space", "running", "0/1", now.Format(time.RFC3339), "0s"}
 
 		// It render the correct data for the rows
 		r.Equal(expectedRow1, row1)
 		r.Equal(expectedRow2, row2)
 		r.Equal(expectedRow3, row3)
 		r.Equal(expectedRow4, row4)
+		r.Equal(expectedRow5, row5)
 
 		// It renders the data at the correct index
 		r.Equal(index1, 1)
 		r.Equal(index2, 2)
 		r.Equal(index3, 3)
 		r.Equal(index4, 4)
+		r.Equal(index5, 5)
 
 		// It renders the rows in the correct color
 		r.Equal(c1, tcell.ColorWhite)
 		r.Equal(c2, tcell.ColorYellow)
 		r.Equal(c3, tcell.ColorRed)
 		r.Equal(c4, tcell.ColorDarkGrey)
+		r.Equal(c5, styles.TcellColorAttention)
 	})
 
 	t.Run("When render called again", func(t *testing.T) {
@@ -132,6 +151,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Namespace:         "space",
 				Status:            "running",
 				StatusDescription: "fine",
+				StatusSummary:     models.Summary{Total: 1, Running: 1},
 				SubmitTime:        now,
 			},
 		}
@@ -247,34 +267,3 @@ func TestJobTable_Sad(t *testing.T) {
 		r.True(errors.Is(err, component.ErrComponentNotBound))
 	})
 }
-
-// 		expectedTableHeader := []string{
-// 			"ID",
-// 			"Name",
-// 			"Type",
-// 			"Namespace",
-// 			"Status",
-// 			"SubmitTime",
-// 			"Uptime",
-// 		}
-
-// 		expectedRows := [][]string{
-// 			{
-// 				"Strawberry",
-// 				"Strawberry",
-// 				"service",
-// 				"default",
-// 				"running",
-// 				now.Format(time.RFC3339),
-// 				"0s",
-// 			},
-// 			{
-// 				"Milchshake",
-// 				"Milchshake",
-// 				"service",
-// 				"default",
-// 				"dead",
-// 				now.Format(time.RFC3339),
-// 				"0s",
-// 			},
-// 		}

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
-github.com/hashicorp/nomad/api v0.0.0-20210709134434-c4e0355775f3 h1:BOBoGSnaNSLtMVDjwMbH9yW40COa8QLOr16dc0IKBns=
-github.com/hashicorp/nomad/api v0.0.0-20210709134434-c4e0355775f3/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/hashicorp/nomad/api v0.0.0-20210804153318-c67b69bd0cc6 h1:kqVyRGdvPCQ3pIgZBvu7ISJZCELxkgSg5qrPO893sLc=
 github.com/hashicorp/nomad/api v0.0.0-20210804153318-c67b69bd0cc6/go.mod h1:vYHP9jMXk4/T2qNUbWlQ1OHCA1hHLil3nvqSmz8mtgc=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=

--- a/models/models.go
+++ b/models/models.go
@@ -27,7 +27,13 @@ type Job struct {
 	Type              string
 	Status            string
 	StatusDescription string
+	StatusSummary     Summary
 	SubmitTime        time.Time
+}
+
+type Summary struct {
+	Total   int
+	Running int
 }
 
 type TaskGroup struct {

--- a/nomad/jobs.go
+++ b/nomad/jobs.go
@@ -34,6 +34,17 @@ func (n *Nomad) Jobs(so *SearchOptions) ([]*models.Job, error) {
 func toJob(j *api.JobListStub) *models.Job {
 	t := time.Unix(0, j.SubmitTime)
 
+	total := len(j.JobSummary.Summary)
+	summary := models.Summary{
+		Total: total,
+	}
+
+	for _, job := range j.JobSummary.Summary {
+		if job.Running > 0 {
+			summary.Running++
+		}
+	}
+
 	return &models.Job{
 		ID:                j.ID,
 		Name:              j.Name,
@@ -41,6 +52,7 @@ func toJob(j *api.JobListStub) *models.Job {
 		Type:              j.Type,
 		Status:            j.Status,
 		StatusDescription: j.StatusDescription,
+		StatusSummary:     summary,
 		SubmitTime:        t,
 	}
 }

--- a/nomad/jobs_test.go
+++ b/nomad/jobs_test.go
@@ -32,6 +32,10 @@ func TestJobs(t *testing.T) {
 				SubmitTime:        now,
 				JobSummary: &api.JobSummary{
 					Namespace: "default",
+					Summary: map[string]api.TaskGroupSummary{
+						"task1": {Running: 0},
+						"task2": {Running: 1},
+					},
 				},
 			},
 			{
@@ -56,6 +60,7 @@ func TestJobs(t *testing.T) {
 			Type:              "service",
 			Status:            "running",
 			StatusDescription: "this is awesome",
+			StatusSummary:     models.Summary{Total: 2, Running: 1},
 			SubmitTime:        nowUnix,
 		}
 


### PR DESCRIPTION
### What is this about?

-> Implements #6

This PR adds an extra column `Summary` to the Job Table, which shows the the current number of running tasks and the total number of tasks for a job (`Running/Total` => eg `2/2`). For `service` jobs the color changes for rows where the number of running jobs isn't equal to the number of the total number of jobs.

