### PR TITLE
HCD-8: Fix Allocations View filter

### DIFF
--- a/view/allocations.go
+++ b/view/allocations.go
@@ -1,6 +1,7 @@
 package view
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/nomad/api"
@@ -79,7 +80,7 @@ func (v *View) filterAllocs(jobID string) []*models.Alloc {
 }
 
 func (v *View) filterAllocsForJob(jobID string) []*models.Alloc {
-	rx, _ := regexp.Compile(jobID)
+	rx, _ := regexp.Compile(fmt.Sprintf("^%s$", jobID))
 	result := []*models.Alloc{}
 	for _, job := range v.state.Allocations {
 		switch true {


### PR DESCRIPTION
### What is this about?

Fixes -> #8 

This PR fixes a bug where the allocation view for a particular job included allocation of another job when the name was a subset of the current name (eg `job` showed up for allocations of `job-two`)

