### PR TITLE
HCD: Implement nomad job status display

### DIFF
--- a/cmd/damon/main.go
+++ b/cmd/damon/main.go
@@ -78,7 +78,7 @@ func main() {
 		Commands:        commands,
 		Logo:            logo,
 		JobTable:        jobs,
-		JobStatus: 		 jobStatus,
+		JobStatus:       jobStatus,
 		DeploymentTable: depl,
 		NamespaceTable:  namespaces,
 		AllocationTable: allocations,

--- a/cmd/damon/main.go
+++ b/cmd/damon/main.go
@@ -53,6 +53,7 @@ func main() {
 	commands := component.NewCommands()
 	logo := component.NewLogo()
 	jobs := component.NewJobsTable()
+	jobStatus := component.NewJobStatus()
 	depl := component.NewDeploymentTable()
 	namespaces := component.NewNamespaceTable()
 	allocations := component.NewAllocationTable()
@@ -77,6 +78,7 @@ func main() {
 		Commands:        commands,
 		Logo:            logo,
 		JobTable:        jobs,
+		JobStatus: 		 jobStatus,
 		DeploymentTable: depl,
 		NamespaceTable:  namespaces,
 		AllocationTable: allocations,

--- a/component/component.go
+++ b/component/component.go
@@ -32,6 +32,25 @@ const (
 	LabelLost     = "Lost"
 	LabelFailed   = "Failed"
 
+	LabelDesired               = "Desired"
+	LabelHealthy               = "Healthy"
+	LabelUnhealthy             = "Unhealthy"
+	LabelPlaced                = "Placed"
+	LabelProgressDeadline      = "Progress Deadline"
+	LabelVersion               = "Version"
+	LabelStatusDescriptionLong = "Status Description"
+	LabelPriority              = "Priority"
+	LabelDatacenters           = "Datacenters"
+	LabelPeriodic              = "Periodic"
+	LabelParameterized         = "Parameterized"
+
+	LabelLatestDeployment = "Latest Deployment"
+	LabelDeployed         = "Deployed"
+	LabelAllocations      = "Allocations"
+
+	LabelCreated  = "Created"
+	LabelModified = "Modified"
+
 	LabelNodeID   = "NodeID"
 	LabelNodeName = "NodeName"
 

--- a/component/job_status.go
+++ b/component/job_status.go
@@ -1,0 +1,48 @@
+package component
+
+import (
+	"github.com/rivo/tview"
+	primitive "github.com/hcjulz/damon/primitives"
+)
+
+type JobStatus struct {
+	TextView TextView
+	Status    string
+	slot     *tview.Flex
+}
+
+func NewJobStatus() *JobStatus {
+	textView := primitive.NewTextView(tview.AlignLeft)
+	textView.ModifyPrimitive(applyModifiers)
+	return &JobStatus{
+		TextView: textView,
+	}
+}
+
+func (jobStatus *JobStatus) Bind(slot *tview.Flex) {
+	jobStatus.slot = slot
+}
+
+func (jobStatus *JobStatus) Render() error {
+	if jobStatus.slot == nil {
+		return ErrComponentNotBound
+	}
+
+	jobStatus.slot.Clear()
+	jobStatus.TextView.Clear()
+
+	if len(jobStatus.Status) > 0 {
+		jobStatus.TextView.SetText(jobStatus.Status)
+	} else {
+		jobStatus.TextView.SetText("Status not available.")
+	}
+	jobStatus.slot.AddItem(jobStatus.TextView.Primitive(), 0, 1, true)
+	return nil
+}
+
+func applyModifiers(t *tview.TextView) {
+	t.SetScrollable(true)
+	t.SetBorder(true)
+	t.ScrollToEnd()
+	t.SetTitle("Job Status")
+}

--- a/component/job_status.go
+++ b/component/job_status.go
@@ -1,14 +1,24 @@
 package component
 
 import (
-	"github.com/rivo/tview"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hcjulz/damon/models"
 	primitive "github.com/hcjulz/damon/primitives"
+	"github.com/olekukonko/tablewriter"
+	"github.com/rivo/tview"
 )
 
 type JobStatus struct {
 	TextView TextView
-	Status    string
+	Props    *JobStatusProps
 	slot     *tview.Flex
+}
+
+type JobStatusProps struct {
+	Data *models.JobStatus
 }
 
 func NewJobStatus() *JobStatus {
@@ -16,6 +26,7 @@ func NewJobStatus() *JobStatus {
 	textView.ModifyPrimitive(applyModifiers)
 	return &JobStatus{
 		TextView: textView,
+		Props:    &JobStatusProps{},
 	}
 }
 
@@ -29,20 +40,174 @@ func (jobStatus *JobStatus) Render() error {
 	}
 
 	jobStatus.slot.Clear()
-	jobStatus.TextView.Clear()
+	jobStatus.slot.SetDirection(tview.FlexRow)
 
-	if len(jobStatus.Status) > 0 {
-		jobStatus.TextView.SetText(jobStatus.Status)
-	} else {
+	if jobStatus.Props.Data.ID == "" {
 		jobStatus.TextView.SetText("Status not available.")
+		return nil
 	}
+
+	var jobStatusText []string
+	jobStatusText = append(jobStatusText,
+		"\n",
+		jobStatus.renderInfoData(),
+		"\n  Summary\n",
+		jobStatus.renderSummary(),
+		"\n  Latest Deployment\n",
+		jobStatus.renderLatestDeployment(),
+		"\n  Deployed\n",
+		jobStatus.renderDeployments(),
+		"\n  Allocations\n",
+		jobStatus.renderAllocs())
+
+	jobStatus.TextView.SetText(strings.Join(jobStatusText, ""))
 	jobStatus.slot.AddItem(jobStatus.TextView.Primitive(), 0, 1, true)
 	return nil
+}
+
+func (jobStatus *JobStatus) renderInfoData() string {
+	j := jobStatus.Props.Data
+
+	tableString := &strings.Builder{}
+	tableWriter := tablewriter.NewWriter(tableString)
+	format(tableWriter)
+
+	frmt := func(value interface{}) string {
+		return fmt.Sprintf("= %s", value)
+	}
+
+	infoData := [][]string{
+		{"ID", frmt(j.ID)},
+		{"Name", frmt(j.Name)},
+		{"Submit Date", frmt(j.SubmitDate.Format("2006-01-02 15:04:05"))},
+		{"Type", frmt(j.Type)},
+		{"Priority", frmt(fmt.Sprint(j.Priority))},
+		{"Datacenters", frmt(j.Datacenters)},
+		{"Namespace", frmt(j.Namespace)},
+		{"Status", frmt(j.Status)},
+		{"Periodic", frmt(fmt.Sprint(j.Periodic))},
+		{"Parameterized", frmt(fmt.Sprint(j.Parameterized))},
+	}
+	tableWriter.AppendBulk(infoData)
+	tableWriter.Render()
+	return tableString.String()
+}
+
+func (jobStatus *JobStatus) renderSummary() string {
+	tasks := jobStatus.Props.Data.TaskGroups
+
+	tableString := &strings.Builder{}
+	tableWriter := tablewriter.NewWriter(tableString)
+	format(tableWriter)
+	tableWriter.SetHeader([]string{"Task Group", "Queued", "Starting", "Running", "Failed", "Complete", "Lost"})
+
+	for _, tg := range tasks {
+		row := []string{
+			tg.Name,
+			fmt.Sprint(tg.Queued),
+			fmt.Sprint(tg.Starting),
+			fmt.Sprint(tg.Running),
+			fmt.Sprint(tg.Failed),
+			fmt.Sprint(tg.Complete),
+			fmt.Sprint(tg.Lost),
+		}
+		tableWriter.Append(row)
+	}
+	tableWriter.Render()
+	return tableString.String()
+}
+
+func (jobStatus *JobStatus) renderLatestDeployment() string {
+	tgs := jobStatus.Props.Data.TaskGroupStatus
+
+	if len(tgs) <= 0 {
+		return ""
+	}
+
+	ts := tgs[0]
+	tableString := &strings.Builder{}
+	tableWriter := tablewriter.NewWriter(tableString)
+	format(tableWriter)
+
+	frmt := func(value interface{}) string {
+		return fmt.Sprintf("= %s", value)
+	}
+
+	infoData := [][]string{
+		{"ID", frmt(ts.ID)},
+		{"Status", frmt(ts.Status)},
+		{"Status Description", frmt(ts.StatusDescription)},
+	}
+	tableWriter.AppendBulk(infoData)
+	tableWriter.Render()
+	return tableString.String()
+}
+
+func (jobStatus *JobStatus) renderDeployments() string {
+	tgs := jobStatus.Props.Data.TaskGroupStatus
+
+	tableString := &strings.Builder{}
+	tableWriter := tablewriter.NewWriter(tableString)
+	format(tableWriter)
+
+	tableWriter.SetHeader([]string{"Task Group", "Desired", "Placed", "Healthy", "Unhealthy", "Progress Deadline"})
+
+	for _, t := range tgs {
+		row := []string{
+			fmt.Sprint(t.ID),
+			fmt.Sprint(t.Desired),
+			fmt.Sprint(t.Placed),
+			fmt.Sprint(t.Healthy),
+			fmt.Sprint(t.Unhealthy),
+			fmt.Sprint(t.ProgressDeadline),
+		}
+		tableWriter.Append(row)
+	}
+	tableWriter.Render()
+	return tableString.String()
+}
+
+func (jobStatus *JobStatus) renderAllocs() string {
+	tgs := jobStatus.Props.Data.Allocations
+
+	tableString := &strings.Builder{}
+	tableWriter := tablewriter.NewWriter(tableString)
+	format(tableWriter)
+
+	tableWriter.SetHeader([]string{"ID", "Node ID", "Task Group", "Version", "Desired", "Status", "Created", "Modified"})
+
+	for _, t := range tgs {
+		row := []string{
+			t.ID[0:8],
+			t.NodeID[0:8],
+			t.TaskGroup,
+			fmt.Sprint(t.Version),
+			t.DesiredStatus,
+			t.Status,
+			fmt.Sprintf("%s ago", time.Since(t.Created).Round(time.Second)),
+			fmt.Sprintf("%s ago", time.Since(t.Modified).Round(time.Second)),
+		}
+		tableWriter.Append(row)
+	}
+	tableWriter.Render()
+	return tableString.String()
+}
+
+func format(tw *tablewriter.Table) {
+	tw.SetBorder(false)
+	tw.SetAutoWrapText(false)
+	tw.SetAutoFormatHeaders(false)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetCenterSeparator("")
+	tw.SetColumnSeparator("")
+	tw.SetRowSeparator("")
+	tw.SetHeaderLine(false)
+	tw.SetTablePadding("\t")
 }
 
 func applyModifiers(t *tview.TextView) {
 	t.SetScrollable(true)
 	t.SetBorder(true)
-	t.ScrollToEnd()
 	t.SetTitle("Job Status")
 }

--- a/component/job_status_test.go
+++ b/component/job_status_test.go
@@ -86,7 +86,7 @@ func TestJobStatus_Happy(t *testing.T) {
 		r.Equal(strings.ReplaceAll(text, " ", ""), `
 ID=fakeID
 Name=fakeName
-SubmitDate=1987-10-1612:45:00
+SubmitTime=1987-10-1612:45:00
 Type=fakeType
 Priority=0
 Datacenters=fakeDC

--- a/component/job_status_test.go
+++ b/component/job_status_test.go
@@ -2,13 +2,16 @@ package component_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hcjulz/damon/component"
 	"github.com/hcjulz/damon/component/componentfakes"
+	"github.com/hcjulz/damon/models"
 )
 
 func TestJobStatus_Happy(t *testing.T) {
@@ -18,7 +21,61 @@ func TestJobStatus_Happy(t *testing.T) {
 		textView := &componentfakes.FakeTextView{}
 		jobStatus := component.NewJobStatus()
 		jobStatus.TextView = textView
-		jobStatus.Status = "Sample Status"
+		jobStatus.Props.Data = &models.JobStatus{
+			ID:                "fakeID",
+			Name:              "fakeName",
+			Namespace:         "fakeNamespace",
+			Type:              "fakeType",
+			Status:            "fakeStatus",
+			StatusDescription: "Some fake description",
+			SubmitDate:        time.Date(1987, 10, 16, 12, 45, 0, 0, time.UTC),
+			Priority:          0,
+			Datacenters:       "fakeDC",
+			Periodic:          false,
+			Parameterized:     false,
+			TaskGroups: []*models.TaskGroup{
+				{
+					Name:     "fakeGroup",
+					JobID:    "fakeJobID",
+					Queued:   10,
+					Complete: 20,
+					Failed:   30,
+					Running:  40,
+					Starting: 50,
+					Lost:     60,
+				},
+			},
+			TaskGroupStatus: []*models.TaskGroupStatus{
+				{
+					ID:                "fakeGroupStatus",
+					Desired:           70,
+					Placed:            80,
+					Healthy:           90,
+					Unhealthy:         100,
+					ProgressDeadline:  200,
+					Status:            "fake Group Status",
+					StatusDescription: "Some fake group description",
+				},
+			},
+			Allocations: []*models.Alloc{
+				{
+					ID:            "1234567890",
+					Name:          "123",
+					TaskGroup:     "fakeAllocGroup",
+					Tasks:         []models.AllocTask{},
+					TaskNames:     []string{},
+					JobID:         "",
+					JobType:       "",
+					NodeID:        "1234567890",
+					NodeName:      "",
+					DesiredStatus: "fake Desired Status",
+					Version:       100,
+					Status:        "fake Alloc Status",
+					Created:       time.Now(),
+					Modified:      time.Now(),
+				},
+			},
+		}
 
 		jobStatus.Bind(tview.NewFlex())
 
@@ -26,14 +83,42 @@ func TestJobStatus_Happy(t *testing.T) {
 		r.NoError(err)
 
 		text := textView.SetTextArgsForCall(0)
-		r.Equal(text, "Sample Status")
+		r.Equal(strings.ReplaceAll(text, " ", ""), `
+ID=fakeID
+Name=fakeName
+SubmitDate=1987-10-1612:45:00
+Type=fakeType
+Priority=0
+Datacenters=fakeDC
+Namespace=fakeNamespace
+Status=fakeStatus
+Periodic=false
+Parameterized=false
+
+Summary
+TaskGroupQueuedStartingRunningFailedCompleteLost
+fakeGroup105040302060
+
+LatestDeployment
+ID=fakeGroupStatus
+Status=fakeGroupStatus
+StatusDescription=Somefakegroupdescription
+
+Deployed
+TaskGroupDesiredPlacedHealthyUnhealthyProgressDeadline
+fakeGroupStatus708090100200ns
+
+Allocations
+IDNodeIDTaskGroupVersionDesiredStatusCreatedModified
+1234567812345678fakeAllocGroup100fakeDesiredStatusfakeAllocStatus0sago0sago
+`)
 	})
 
 	t.Run("When there is no data to render", func(t *testing.T) {
 		textView := &componentfakes.FakeTextView{}
 		jobStatus := component.NewJobStatus()
 		jobStatus.TextView = textView
-		jobStatus.Status = ""
+		jobStatus.Props.Data = &models.JobStatus{}
 
 		jobStatus.Bind(tview.NewFlex())
 

--- a/component/job_status_test.go
+++ b/component/job_status_test.go
@@ -1,0 +1,60 @@
+package component_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hcjulz/damon/component"
+	"github.com/hcjulz/damon/component/componentfakes"
+)
+
+func TestJobStatus_Happy(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("When there is data to render", func(t *testing.T) {
+		textView := &componentfakes.FakeTextView{}
+		jobStatus := component.NewJobStatus()
+		jobStatus.TextView = textView
+		jobStatus.Status = "Sample Status"
+
+		jobStatus.Bind(tview.NewFlex())
+
+		err := jobStatus.Render()
+		r.NoError(err)
+
+		text := textView.SetTextArgsForCall(0)
+		r.Equal(text, "Sample Status")
+	})
+
+	t.Run("When there is no data to render", func(t *testing.T) {
+		textView := &componentfakes.FakeTextView{}
+		jobStatus := component.NewJobStatus()
+		jobStatus.TextView = textView
+		jobStatus.Status = ""
+
+		jobStatus.Bind(tview.NewFlex())
+
+		err := jobStatus.Render()
+		r.NoError(err)
+
+		text := textView.SetTextArgsForCall(0)
+		r.Equal(text, "Status not available.")
+	})
+}
+
+func TestJobStatus_Sad(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("When the component is not bound", func(t *testing.T) {
+		jobStatus := component.NewJobStatus()
+
+		err := jobStatus.Render()
+		r.Error(err)
+
+		r.True(errors.Is(err, component.ErrComponentNotBound))
+		r.EqualError(err, "component not bound")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/nomad/api v0.0.0-20210804153318-c67b69bd0cc6
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/rivo/tview v0.0.0-20210427112837-09cec83b1732
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -39,6 +40,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/tview v0.0.0-20210427112837-09cec83b1732 h1:sY3Egm/ld9GcxAUs5zBPo1lEzC15ZteptMJmd8Ltc6Q=

--- a/models/models.go
+++ b/models/models.go
@@ -17,6 +17,7 @@ const (
 
 	TopicNamespace api.Topic = api.Topic("Namespace")
 	TopicTaskGroup api.Topic = api.Topic("TaskGroup")
+	TopicJobStatus api.Topic = api.Topic("JobStatus")
 	TopicLog       api.Topic = api.Topic("Log")
 )
 
@@ -29,6 +30,23 @@ type Job struct {
 	StatusDescription string
 	StatusSummary     Summary
 	SubmitTime        time.Time
+}
+
+type JobStatus struct {
+	ID                string
+	Name              string
+	Namespace         string
+	Type              string
+	Status            string
+	StatusDescription string
+	SubmitDate        time.Time
+	Priority          int
+	Datacenters       string
+	Periodic          bool
+	Parameterized     bool
+	TaskGroups        []*TaskGroup
+	TaskGroupStatus   []*TaskGroupStatus
+	Allocations       []*Alloc
 }
 
 type Summary struct {
@@ -47,6 +65,17 @@ type TaskGroup struct {
 	Lost     int
 }
 
+type TaskGroupStatus struct {
+	ID                string
+	Desired           int
+	Placed            int
+	Healthy           int
+	Unhealthy         int
+	ProgressDeadline  time.Duration
+	Status            string
+	StatusDescription string
+}
+
 type Alloc struct {
 	ID            string
 	Name          string
@@ -58,6 +87,10 @@ type Alloc struct {
 	NodeID        string
 	NodeName      string
 	DesiredStatus string
+	Version       uint64
+	Status        string
+	Created       time.Time
+	Modified      time.Time
 }
 
 type AllocTask struct {

--- a/nomad/alloc.go
+++ b/nomad/alloc.go
@@ -1,6 +1,8 @@
 package nomad
 
 import (
+	"time"
+
 	"github.com/hashicorp/nomad/api"
 
 	"github.com/hcjulz/damon/models"
@@ -54,6 +56,10 @@ func toAllocs(list []*api.AllocationListStub) []*models.Alloc {
 			NodeID:        el.NodeID,
 			NodeName:      el.NodeName,
 			DesiredStatus: el.DesiredStatus,
+			Version:       el.JobVersion,
+			Status:        el.ClientStatus,
+			Created:       time.Unix(0, el.CreateTime),
+			Modified:      time.Unix(0, el.ModifyTime),
 		}
 
 		for k, t := range el.TaskStates {

--- a/nomad/alloc_test.go
+++ b/nomad/alloc_test.go
@@ -31,6 +31,10 @@ func TestJobAllocs(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				JobVersion:    100,
+				ClientStatus:  "ClientStatus",
+				CreateTime:    100,
+				ModifyTime:    100,
 				TaskStates: map[string]*api.TaskState{
 					"task-1": {
 						Events: []*api.TaskEvent{
@@ -51,6 +55,10 @@ func TestJobAllocs(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				JobVersion:    200,
+				ClientStatus:  "ClientStatus",
+				CreateTime:    200,
+				ModifyTime:    200,
 				TaskStates: map[string]*api.TaskState{
 					"task-2": {
 						Events: []*api.TaskEvent{
@@ -81,6 +89,10 @@ func TestJobAllocs(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				Version:       100,
+				Status:        "ClientStatus",
+				Created:       time.Unix(0, 100),
+				Modified:      time.Unix(0, 100),
 				TaskNames:     []string{"task-1"},
 				Tasks: []models.AllocTask{
 					{
@@ -103,6 +115,10 @@ func TestJobAllocs(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				Version:       200,
+				Status:        "ClientStatus",
+				Created:       time.Unix(0, 200),
+				Modified:      time.Unix(0, 200),
 				TaskNames:     []string{"task-2"},
 				Tasks: []models.AllocTask{
 					{
@@ -162,6 +178,10 @@ func TestAllocations(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				JobVersion:    100,
+				ClientStatus:  "ClientStatus",
+				CreateTime:    100,
+				ModifyTime:    100,
 			},
 			{
 				ID:            "id-two",
@@ -171,6 +191,10 @@ func TestAllocations(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				JobVersion:    200,
+				ClientStatus:  "ClientStatus",
+				CreateTime:    200,
+				ModifyTime:    200,
 			},
 		}, &api.QueryMeta{}, nil)
 
@@ -190,6 +214,10 @@ func TestAllocations(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				Version:       100,
+				Status:        "ClientStatus",
+				Created:       time.Unix(0, 100),
+				Modified:      time.Unix(0, 100),
 			},
 			{
 				ID:            "id-two",
@@ -199,6 +227,10 @@ func TestAllocations(t *testing.T) {
 				NodeID:        "node-id",
 				NodeName:      "nodejs",
 				DesiredStatus: "skate",
+				Version:       200,
+				Status:        "ClientStatus",
+				Created:       time.Unix(0, 200),
+				Modified:      time.Unix(0, 200),
 			},
 		}
 

--- a/nomad/job_status.go
+++ b/nomad/job_status.go
@@ -17,10 +17,7 @@ func (n *Nomad) JobStatus(jobID string, so *SearchOptions) (*models.JobStatus, e
 
 	taskgroups, _ := n.TaskGroups(jobID, so)
 
-	info, _, err := n.JobClient.Info(jobID, &api.QueryOptions{
-		Namespace: so.Namespace,
-		Region:    so.Region,
-	})
+	info, err := n.GetJob(jobID)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve job info: %w", err)

--- a/nomad/job_status.go
+++ b/nomad/job_status.go
@@ -1,0 +1,92 @@
+package nomad
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+
+	"github.com/hcjulz/damon/models"
+)
+
+func (n *Nomad) JobStatus(jobID string, so *SearchOptions) (*models.JobStatus, error) {
+	if so == nil {
+		so = &SearchOptions{}
+	}
+
+	taskgroups, _ := n.TaskGroups(jobID, so)
+
+	info, _, err := n.JobClient.Info(jobID, &api.QueryOptions{
+		Namespace: so.Namespace,
+		Region:    so.Region,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve job info: %w", err)
+	}
+
+	d, _, err := n.DpClient.List(&api.QueryOptions{
+		Namespace: so.Namespace,
+		Region:    so.Region,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve job deployments: %w", err)
+	}
+
+	taskGroupStatus := toTaskGroupStatus(jobID, d)
+
+	allocations, _ := n.JobAllocs(jobID, so)
+
+	if err != nil {
+		return nil, err
+	}
+
+	jobStatus := toJobStatus(info, taskgroups, taskGroupStatus, allocations)
+
+	return jobStatus, nil
+}
+
+func toJobStatus(job *api.Job, tasks []*models.TaskGroup, taskStatus []*models.TaskGroupStatus, allocs []*models.Alloc) *models.JobStatus {
+	jobStatus := &models.JobStatus{
+		ID:              *job.ID,
+		Name:            *job.Name,
+		SubmitDate:      time.Unix(0, *job.SubmitTime),
+		Type:            *job.Type,
+		Priority:        *job.Priority,
+		Datacenters:     strings.Join(job.Datacenters, ", "),
+		Namespace:       *job.Namespace,
+		Status:          *job.Status,
+		Periodic:        job.Periodic != nil,
+		Parameterized:   job.ParameterizedJob != nil,
+		TaskGroups:      tasks,
+		TaskGroupStatus: taskStatus,
+		Allocations:     allocs,
+	}
+
+	return jobStatus
+}
+
+func toTaskGroupStatus(jobID string, dep []*api.Deployment) []*models.TaskGroupStatus {
+	result := make([]*models.TaskGroupStatus, 0., len(dep))
+	for _, d := range dep {
+		if d.JobID == jobID {
+			for _, t := range d.TaskGroups {
+				result = append(result, &models.TaskGroupStatus{
+					ID:                d.JobID,
+					Status:            d.Status,
+					StatusDescription: d.StatusDescription,
+					Desired:           t.DesiredTotal,
+					Placed:            t.PlacedAllocs,
+					Healthy:           t.HealthyAllocs,
+					Unhealthy:         t.UnhealthyAllocs,
+					ProgressDeadline:  t.ProgressDeadline,
+				})
+			}
+			break // * Deployments are already sorted. So break once you find your's.
+		}
+
+	}
+	return result
+}

--- a/nomad/job_status_test.go
+++ b/nomad/job_status_test.go
@@ -1,0 +1,150 @@
+package nomad_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hcjulz/damon/models"
+	"github.com/hcjulz/damon/nomad"
+	"github.com/hcjulz/damon/nomad/nomadfakes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobStatus(t *testing.T) {
+	r := require.New(t)
+
+	fakeJobClient := &nomadfakes.FakeJobClient{}
+	fakeDpClient := &nomadfakes.FakeDeploymentClient{}
+	client := &nomad.Nomad{JobClient: fakeJobClient, DpClient: fakeDpClient}
+
+	t.Run("When there are no issues", func(t *testing.T) {
+		now := time.Now().UnixNano()
+		nowUnix := time.Unix(0, now)
+
+		id := "fakeID"
+		name := "fakeName"
+		fakeType := "fakeType"
+		status := "fakestatus"
+		value := 100
+		ns := "ns"
+		fakeTaskGroup := "fakeTaskGroup"
+
+		fakeJobClient.InfoReturns(&api.Job{
+			ID:         &id,
+			Name:       &name,
+			Type:       &fakeType,
+			Priority:   &value,
+			Status:     &status,
+			SubmitTime: &now,
+			Namespace:  &ns,
+			TaskGroups: []*api.TaskGroup{
+				{
+					Name: &fakeTaskGroup,
+				},
+			},
+		}, nil, nil)
+
+		fakeJobClient.SummaryReturns(&api.JobSummary{
+			JobID: "fakejobId",
+			Summary: map[string]api.TaskGroupSummary{
+				"Mandalorian": {
+					Running: 1,
+					Queued:  1,
+				},
+				"Grogu": {
+					Failed: 1,
+					Queued: 1,
+				},
+			},
+		}, nil, nil)
+
+		fakeDpClient.ListReturns([]*api.Deployment{
+			{
+				JobID: "fakeID",
+				TaskGroups: map[string]*api.DeploymentState{
+					"dp1": {
+						HealthyAllocs:   1,
+						UnhealthyAllocs: 0,
+					},
+				},
+			},
+		}, nil, nil)
+
+		so := nomad.SearchOptions{Namespace: "default"}
+
+		jobStatus, err := client.JobStatus("fakeID", &so)
+
+		jId, queryOptions := fakeJobClient.InfoArgsForCall(0)
+
+		expectedJobStatus := &models.JobStatus{
+			ID:         id,
+			Name:       name,
+			Type:       fakeType,
+			Status:     status,
+			SubmitDate: nowUnix,
+			Namespace:  ns,
+			Priority:   value,
+			TaskGroups: []*models.TaskGroup{
+				{
+					Name:     "Grogu",
+					JobID:    "fakejobId",
+					Queued:   1,
+					Complete: 0,
+					Failed:   1,
+					Running:  0,
+					Starting: 0,
+					Lost:     0,
+				},
+				{
+					Name:     "Mandalorian",
+					JobID:    "fakejobId",
+					Queued:   1,
+					Complete: 0,
+					Failed:   0,
+					Running:  1,
+					Starting: 0,
+					Lost:     0,
+				},
+			},
+			Allocations: []*models.Alloc{},
+			TaskGroupStatus: []*models.TaskGroupStatus{
+				{
+					ID:                "fakeID",
+					Healthy:           1,
+					Unhealthy:         0,
+					Desired:           0,
+					Placed:            0,
+					ProgressDeadline:  0,
+					Status:            "",
+					StatusDescription: "",
+				},
+			},
+		}
+
+		expectedQueryOptions := &api.QueryOptions{Namespace: "default"}
+
+		//check that no error occured
+		r.NoError(err)
+
+		r.Equal(jId, "fakeID")
+
+		//check that List() was called once
+		r.Equal(fakeJobClient.InfoCallCount(), 1)
+
+		//check that the query params where passed correctly
+		r.Equal(queryOptions, expectedQueryOptions)
+
+		//check all fields are set
+		r.Equal(expectedJobStatus, jobStatus)
+	})
+
+	t.Run("When there is a problem with the client", func(t *testing.T) {
+		fakeJobClient.InfoReturns(nil, nil, errors.New("aaah"))
+		_, err := client.JobStatus("", nil)
+
+		r.Error(err)
+		r.Contains(err.Error(), "failed to retrieve job info")
+	})
+}

--- a/nomad/job_status_test.go
+++ b/nomad/job_status_test.go
@@ -123,8 +123,6 @@ func TestJobStatus(t *testing.T) {
 			},
 		}
 
-		expectedQueryOptions := &api.QueryOptions{Namespace: "default"}
-
 		//check that no error occured
 		r.NoError(err)
 
@@ -134,7 +132,7 @@ func TestJobStatus(t *testing.T) {
 		r.Equal(fakeJobClient.InfoCallCount(), 1)
 
 		//check that the query params where passed correctly
-		r.Equal(queryOptions, expectedQueryOptions)
+		r.Nil(queryOptions)
 
 		//check all fields are set
 		r.Equal(expectedJobStatus, jobStatus)

--- a/state/state.go
+++ b/state/state.go
@@ -17,6 +17,7 @@ type State struct {
 	Allocations []*models.Alloc
 	Namespaces  []*models.Namespace
 	Logs        []byte
+	JobStatus	string
 
 	SelectedNamespace string
 	SelectedRegion    string

--- a/state/state.go
+++ b/state/state.go
@@ -17,7 +17,7 @@ type State struct {
 	Allocations []*models.Alloc
 	Namespaces  []*models.Namespace
 	Logs        []byte
-	JobStatus	string
+	JobStatus   *models.JobStatus
 
 	SelectedNamespace string
 	SelectedRegion    string

--- a/view/init.go
+++ b/view/init.go
@@ -72,6 +72,9 @@ func (v *View) Init(version string) {
 
 	v.components.JobTable.Props.HandleNoResources = v.handleNoResources
 
+	// JobStatus
+	v.components.JobStatus.Bind(v.Layout.Body)
+
 	// DeploymentTable
 	v.components.DeploymentTable.Bind(v.Layout.Body)
 	v.components.DeploymentTable.Props.SelectDeployment = func(jobID string) {

--- a/view/job_status.go
+++ b/view/job_status.go
@@ -1,0 +1,40 @@
+package view
+
+import (
+	"os/exec"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hcjulz/damon/models"
+)
+
+func (v *View) JobStatus(jobID string) {
+	v.Layout.Body.Clear()
+
+	v.Layout.Container.SetInputCapture(v.InputMainCommands)
+	v.Layout.Container.SetFocus(v.components.JobStatus.TextView.Primitive())
+	
+	jobStatus := v.components.JobStatus
+	jobStatus.Status = "Loading..."
+	jobStatus.Render()
+	
+	update := func() {
+
+		cmd := exec.Command("nomad", "status", jobID)
+		stdout,err := cmd.Output()
+
+		if err != nil {
+			jobStatus.Status = string(err.Error()) 
+		}else {
+			jobStatus.Status = string(stdout)
+		}
+
+		jobStatus.Render()
+		v.Draw()
+	}
+
+	v.Watcher.Subscribe(api.TopicJob, update)
+	go update()
+
+	v.addToHistory(v.state.SelectedNamespace, models.TopicLog, update)
+	v.Layout.Container.SetInputCapture(v.InputMainCommands)
+}

--- a/view/job_status.go
+++ b/view/job_status.go
@@ -1,9 +1,6 @@
 package view
 
 import (
-	"os/exec"
-
-	"github.com/hashicorp/nomad/api"
 	"github.com/hcjulz/damon/models"
 )
 
@@ -12,28 +9,18 @@ func (v *View) JobStatus(jobID string) {
 
 	v.Layout.Container.SetInputCapture(v.InputMainCommands)
 	v.Layout.Container.SetFocus(v.components.JobStatus.TextView.Primitive())
-	
+
 	jobStatus := v.components.JobStatus
-	jobStatus.Status = "Loading..."
-	jobStatus.Render()
-	
+
 	update := func() {
-
-		cmd := exec.Command("nomad", "status", jobID)
-		stdout,err := cmd.Output()
-
-		if err != nil {
-			jobStatus.Status = string(err.Error()) 
-		}else {
-			jobStatus.Status = string(stdout)
-		}
+		jobStatus.Props.Data = v.state.JobStatus
 
 		jobStatus.Render()
 		v.Draw()
 	}
 
-	v.Watcher.Subscribe(api.TopicJob, update)
-	go update()
+	v.Watcher.SubscribeToJobStatus(jobID, update)
+	update()
 
 	v.addToHistory(v.state.SelectedNamespace, models.TopicLog, update)
 	v.Layout.Container.SetInputCapture(v.InputMainCommands)

--- a/view/jobs.go
+++ b/view/jobs.go
@@ -115,7 +115,7 @@ func (v *View) inputJobs(event *tcell.EventKey) *tcell.EventKey {
 
 			jobID := v.components.JobTable.GetIDForSelection()
 			v.TaskGroups(jobID)
-		
+
 		case 'i':
 			if v.Layout.Footer.HasFocus() || v.components.Search.InputField.Primitive().HasFocus() {
 				return event

--- a/view/jobs.go
+++ b/view/jobs.go
@@ -115,6 +115,14 @@ func (v *View) inputJobs(event *tcell.EventKey) *tcell.EventKey {
 
 			jobID := v.components.JobTable.GetIDForSelection()
 			v.TaskGroups(jobID)
+		
+		case 'i':
+			if v.Layout.Footer.HasFocus() || v.components.Search.InputField.Primitive().HasFocus() {
+				return event
+			}
+
+			jobID := v.components.JobTable.GetIDForSelection()
+			v.JobStatus(jobID)
 
 		case '/':
 			if !v.Layout.Footer.HasFocus() {

--- a/view/view.go
+++ b/view/view.go
@@ -28,6 +28,7 @@ type Watcher interface {
 	SubscribeHandler(handler models.Handler, handle func(string, ...interface{}))
 	SubscribeToNamespaces(notify func())
 	SubscribeToTaskGroups(jobID string, notify func()) error
+	SubscribeToJobStatus(jobID string, notify func()) error
 	SubscribeToLogs(allocID, source string, notify func())
 
 	ForceUpdate()
@@ -53,7 +54,7 @@ type Components struct {
 	Commands        *component.Commands
 	Logo            *component.Logo
 	JobTable        *component.JobTable
-	JobStatus		*component.JobStatus
+	JobStatus       *component.JobStatus
 	DeploymentTable *component.DeploymentTable
 	NamespaceTable  *component.NamespaceTable
 	AllocationTable *component.AllocationTable

--- a/view/view.go
+++ b/view/view.go
@@ -53,6 +53,7 @@ type Components struct {
 	Commands        *component.Commands
 	Logo            *component.Logo
 	JobTable        *component.JobTable
+	JobStatus		*component.JobStatus
 	DeploymentTable *component.DeploymentTable
 	NamespaceTable  *component.NamespaceTable
 	AllocationTable *component.AllocationTable

--- a/watcher/jobStatus.go
+++ b/watcher/jobStatus.go
@@ -1,0 +1,43 @@
+package watcher
+
+import (
+	"time"
+
+	"github.com/hcjulz/damon/models"
+)
+
+// SubscribeToJobStatus starts a goroutine to polls JobStatus every two
+// seconds to update the state. The goroutine will be stopped whenever
+// a new subscription happens.
+func (w *Watcher) SubscribeToJobStatus(jobID string, notify func()) error {
+	w.updateJobStatus(jobID)
+	w.Subscribe(models.TopicJobStatus, notify)
+	w.Notify(models.TopicJobStatus)
+
+	stop := make(chan struct{})
+	w.activities.Add(stop)
+
+	ticker := time.NewTicker(time.Second * 2)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				w.updateJobStatus(jobID)
+				w.Notify(models.TopicJobStatus)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (w *Watcher) updateJobStatus(jobID string) {
+	js, err := w.nomad.JobStatus(jobID, nil)
+	if err != nil {
+		w.NotifyHandler(models.HandleError, err.Error())
+	}
+
+	w.state.JobStatus = js
+}

--- a/watcher/jobStatus_test.go
+++ b/watcher/jobStatus_test.go
@@ -1,0 +1,120 @@
+package watcher_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hcjulz/damon/models"
+	"github.com/hcjulz/damon/state"
+	"github.com/hcjulz/damon/watcher"
+	"github.com/hcjulz/damon/watcher/watcherfakes"
+)
+
+func TestSubscribeToJobStatus_Happy(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("It notifies the subscriber initially", func(t *testing.T) {
+		// SubscribeToJobStatus runs a goroutine that polls Nomad based on the given
+		// interval to fetch JobStatus and notify the subscriber (if subscribed to JobStatus).
+		// Before the goroutine starts it performs an initial fetch to avoid a delay in the
+		// size of the interval duration.
+		// In this case we test if this initial call happens.
+
+		nomad := &watcherfakes.FakeNomad{}
+		state := state.New()
+		watcher := watcher.NewWatcher(state, nomad, time.Millisecond*250)
+
+		expectedNSFirstCall := &models.JobStatus{Name: "foo"}
+
+		done := make(chan struct{})
+
+		var callCount int
+		notifier := func() {
+			callCount++
+			switch callCount {
+			case 1:
+				r.Equal(expectedNSFirstCall, state.JobStatus)
+			case 2:
+				// wait for the goroutine to do his first call
+				// and finish the test.
+				done <- struct{}{}
+			}
+		}
+
+		nomad.JobStatusReturnsOnCall(0, &models.JobStatus{
+			Name: "foo",
+		}, nil)
+
+		nomad.JobStatusReturnsOnCall(1, &models.JobStatus{
+			Name: "bar",
+		}, nil)
+
+		watcher.SubscribeToJobStatus("myJob", notifier)
+
+		<-done
+	})
+
+	t.Run("It continues to notify the subscriber after the initial notification", func(t *testing.T) {
+		// SubscribeToJobStatus runs a goroutine that polls Nomad based on the given
+		// interval to fetch JobStatus and notify the subscriber (if subscribed to JobStatus).
+		// In this case we test if fetch happes.
+
+		nomad := &watcherfakes.FakeNomad{}
+		state := state.New()
+		watcher := watcher.NewWatcher(state, nomad, time.Millisecond*250)
+
+		expectedNSSecondCall := &models.JobStatus{Name: "foo"}
+
+		done := make(chan struct{})
+
+		var callCount int
+		notifier := func() {
+			callCount++
+			switch callCount {
+			case 3:
+				// make sure that the test finishes
+				// and avoid blocking if the assertion
+				// fails.
+				defer func() { done <- struct{}{} }()
+
+				r.Equal(expectedNSSecondCall, state.JobStatus)
+			}
+		}
+
+		nomad.JobStatusReturnsOnCall(2, &models.JobStatus{
+			Name: "foo",
+		}, nil)
+
+		watcher.SubscribeToJobStatus("myJob", notifier)
+
+		<-done
+
+		r.Equal(callCount, 3)
+	})
+
+}
+
+func TestSubscribeToJobStatus_Sad(t *testing.T) {
+	// In this case we test that the Error handler
+	// is called when nomad returns an error.
+
+	r := require.New(t)
+
+	nomad := &watcherfakes.FakeNomad{}
+	state := state.New()
+	watcher := watcher.NewWatcher(state, nomad, time.Millisecond*250)
+
+	var called bool
+	watcher.SubscribeHandler(models.HandleError, func(_ string, _ ...interface{}) {
+		called = true
+	})
+
+	nomad.JobStatusReturns(nil, errors.New("argh"))
+
+	watcher.SubscribeToJobStatus("myJob", func() {})
+
+	r.True(called)
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -20,6 +20,7 @@ type Activities interface {
 type Nomad interface {
 	Address() string
 	Jobs(*nomad.SearchOptions) ([]*models.Job, error)
+	JobStatus(string, *nomad.SearchOptions) (*models.JobStatus, error)
 	Namespaces(*nomad.SearchOptions) ([]*models.Namespace, error)
 	Deployments(*nomad.SearchOptions) ([]*models.Deployment, error)
 	TaskGroups(string, *nomad.SearchOptions) ([]*models.TaskGroup, error)

--- a/watcher/watcherfakes/fake_nomad.go
+++ b/watcher/watcherfakes/fake_nomad.go
@@ -103,6 +103,20 @@ type FakeNomad struct {
 		result1 []*models.Namespace
 		result2 error
 	}
+	JobStatusStub        func(string, *nomad.SearchOptions) (*models.JobStatus, error)
+	jobstatusMutex       sync.RWMutex
+	jobstatusArgsForCall []struct {
+		arg1 string
+		arg2 *nomad.SearchOptions
+	}
+	jobstatusReturns struct {
+		result1 *models.JobStatus
+		result2 error
+	}
+	jobstatusReturnsOnCall map[int]struct {
+		result1 *models.JobStatus
+		result2 error
+	}
 	StreamStub        func(nomad.Topics, uint64) (<-chan *api.Events, error)
 	streamMutex       sync.RWMutex
 	streamArgsForCall []struct {
@@ -576,6 +590,71 @@ func (fake *FakeNomad) NamespacesReturnsOnCall(i int, result1 []*models.Namespac
 	}{result1, result2}
 }
 
+func (fake *FakeNomad) JobStatusCallCount() int {
+	fake.jobstatusMutex.RLock()
+	defer fake.jobstatusMutex.RUnlock()
+	return len(fake.jobstatusArgsForCall)
+}
+
+func (fake *FakeNomad) JobStatusCalls(stub func(string, *nomad.SearchOptions) (*models.JobStatus, error)) {
+	fake.jobstatusMutex.Lock()
+	defer fake.jobstatusMutex.Unlock()
+	fake.JobStatusStub = stub
+}
+
+func (fake *FakeNomad) JobStatusForCall(i int) *nomad.SearchOptions {
+	fake.namespacesMutex.RLock()
+	defer fake.namespacesMutex.RUnlock()
+	argsForCall := fake.namespacesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeNomad) JobStatus(arg1 string, arg2 *nomad.SearchOptions) (*models.JobStatus, error) {
+	fake.jobstatusMutex.Lock()
+	ret, specificReturn := fake.jobstatusReturnsOnCall[len(fake.jobstatusArgsForCall)]
+	fake.jobstatusArgsForCall = append(fake.jobstatusArgsForCall, struct {
+		arg1 string
+		arg2 *nomad.SearchOptions
+	}{arg1, arg2})
+	stub := fake.JobStatusStub
+	fakeReturns := fake.jobstatusReturns
+	fake.recordInvocation("JobStatus", []interface{}{arg1})
+	fake.jobstatusMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeNomad) JobStatusReturnsOnCall(i int, result1 *models.JobStatus, result2 error) {
+	fake.jobstatusMutex.Lock()
+	defer fake.jobstatusMutex.Unlock()
+	fake.JobStatusStub = nil
+	if fake.jobstatusReturnsOnCall == nil {
+		fake.jobstatusReturnsOnCall = make(map[int]struct {
+			result1 *models.JobStatus
+			result2 error
+		})
+	}
+	fake.jobstatusReturnsOnCall[i] = struct {
+		result1 *models.JobStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeNomad) JobStatusReturns(result1 *models.JobStatus, result2 error) {
+	fake.jobstatusMutex.Lock()
+	defer fake.jobstatusMutex.Unlock()
+	fake.JobStatusStub = nil
+	fake.jobstatusReturns = struct {
+		result1 *models.JobStatus
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeNomad) Stream(arg1 nomad.Topics, arg2 uint64) (<-chan *api.Events, error) {
 	fake.streamMutex.Lock()
 	ret, specificReturn := fake.streamReturnsOnCall[len(fake.streamArgsForCall)]
@@ -727,6 +806,8 @@ func (fake *FakeNomad) Invocations() map[string][][]interface{} {
 	defer fake.streamMutex.RUnlock()
 	fake.taskGroupsMutex.RLock()
 	defer fake.taskGroupsMutex.RUnlock()
+	fake.jobstatusMutex.RLock()
+	defer fake.jobstatusMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
### What is this about?
This PR adds the nomad job status view to Damon, which can be displayed when hitting ` i ` on a selected job in the jobs view. The status gives the exact same response as the command `nomad job status <job-id>`

### Preview
<img width="1783" alt="nomad-job-status" src="https://user-images.githubusercontent.com/14835387/134936639-f6e7e981-843a-4bed-8b28-3c08e7a95a39.png">
