### PR TITLE
Show healthy / desired allocs in job summary #17

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -24,6 +24,7 @@ const (
 	LabelTaskGroup         = "TaskGroup"
 	LabelTime              = "Time"
 	LabelMessage           = "Message"
+	LabelReady             = "Ready"
 
 	LabelRunning  = "Running"
 	LabelStarting = "Starting"

--- a/component/job_table_test.go
+++ b/component/job_table_test.go
@@ -35,6 +35,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Status:            "running",
 				StatusDescription: "fine",
 				StatusSummary:     models.Summary{Total: 2, Running: 2},
+				ReadyStatus:       models.ReadyStatus{Desired: 2, Running: 2, Healthy: 2},
 				SubmitTime:        now,
 			},
 			{
@@ -45,6 +46,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Status:            "pending",
 				StatusDescription: "fine",
 				StatusSummary:     models.Summary{Total: 2, Running: 2},
+				ReadyStatus:       models.ReadyStatus{Desired: 2, Running: 2, Healthy: 2},
 				SubmitTime:        now,
 			},
 			{
@@ -55,6 +57,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Status:            "dead",
 				StatusDescription: "fine",
 				StatusSummary:     models.Summary{Total: 1, Running: 1},
+				ReadyStatus:       models.ReadyStatus{Desired: 1, Running: 1, Healthy: 1},
 				SubmitTime:        now,
 			},
 			{
@@ -62,8 +65,9 @@ func TestJobTable_Happy(t *testing.T) {
 				Name:              "mars",
 				Type:              "batch",
 				Namespace:         "space",
-				Status:            "dead",
+				Status:            "running",
 				StatusSummary:     models.Summary{Total: 1, Running: 0},
+				ReadyStatus:       models.ReadyStatus{Desired: 1, Running: 1, Healthy: 0},
 				StatusDescription: "fine",
 				SubmitTime:        now,
 			},
@@ -74,6 +78,7 @@ func TestJobTable_Happy(t *testing.T) {
 				Namespace:         "space",
 				Status:            "running",
 				StatusSummary:     models.Summary{Total: 1, Running: 0},
+				ReadyStatus:       models.ReadyStatus{Desired: 1, Running: 1, Healthy: 0, Unhealthy: 1},
 				StatusDescription: "fine",
 				SubmitTime:        now,
 			},
@@ -107,11 +112,11 @@ func TestJobTable_Happy(t *testing.T) {
 		row4, index4, c4 := fakeTable.RenderRowArgsForCall(3)
 		row5, index5, c5 := fakeTable.RenderRowArgsForCall(4)
 
-		expectedRow1 := []string{"ichi", "saturn", "service", "space", "running", "2/2", now.Format(time.RFC3339), "0s"}
-		expectedRow2 := []string{"ni", "jupiter", "service", "space", "pending", "2/2", now.Format(time.RFC3339), "0s"}
-		expectedRow3 := []string{"san", "neptun", "service", "space", "dead", "1/1", now.Format(time.RFC3339), "0s"}
-		expectedRow4 := []string{"chi", "mars", "batch", "space", "dead", "0/1", now.Format(time.RFC3339), "0s"}
-		expectedRow5 := []string{"yo", "venus", "service", "space", "running", "0/1", now.Format(time.RFC3339), "0s"}
+		expectedRow1 := []string{"ichi", "saturn", "service", "space", "running", "2/2 ✅", now.Format(time.RFC3339), "0s"}
+		expectedRow2 := []string{"ni", "jupiter", "service", "space", "pending", "---", now.Format(time.RFC3339), "0s"}
+		expectedRow3 := []string{"san", "neptun", "service", "space", "dead", "---", now.Format(time.RFC3339), "0s"}
+		expectedRow4 := []string{"chi", "mars", "batch", "space", "running", "0/1 ⚠️", now.Format(time.RFC3339), "0s"}
+		expectedRow5 := []string{"yo", "venus", "service", "space", "running", "0/1 ❌", now.Format(time.RFC3339), "0s"}
 
 		// It render the correct data for the rows
 		r.Equal(expectedRow1, row1)
@@ -129,10 +134,10 @@ func TestJobTable_Happy(t *testing.T) {
 
 		// It renders the rows in the correct color
 		r.Equal(c1, tcell.ColorWhite)
-		r.Equal(c2, tcell.ColorYellow)
-		r.Equal(c3, tcell.ColorRed)
-		r.Equal(c4, tcell.ColorDarkGrey)
-		r.Equal(c5, styles.TcellColorAttention)
+		r.Equal(c2, tcell.ColorDarkGrey)
+		r.Equal(c3, tcell.ColorDarkGrey)
+		r.Equal(c4, tcell.ColorWhite)
+		r.Equal(c5, tcell.ColorRed)
 	})
 
 	t.Run("When render called again", func(t *testing.T) {

--- a/models/models.go
+++ b/models/models.go
@@ -30,6 +30,8 @@ type Job struct {
 	StatusDescription string
 	StatusSummary     Summary
 	SubmitTime        time.Time
+	ReadyStatus       ReadyStatus
+	DeploymentStatus  string
 }
 
 type JobStatus struct {
@@ -47,6 +49,13 @@ type JobStatus struct {
 	TaskGroups        []*TaskGroup
 	TaskGroupStatus   []*TaskGroupStatus
 	Allocations       []*Alloc
+}
+
+type ReadyStatus struct {
+	Desired   int
+	Running   int
+	Healthy   int
+	Unhealthy int
 }
 
 type Summary struct {

--- a/view/jobs.go
+++ b/view/jobs.go
@@ -47,6 +47,7 @@ func (v *View) Jobs() {
 	}
 
 	v.Watcher.Subscribe(api.TopicJob, update)
+	v.Watcher.Subscribe(api.TopicAllocation, update)
 	if len(v.state.Jobs) == 0 {
 		v.Watcher.ForceUpdate()
 	}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -156,7 +156,10 @@ func (w *Watcher) update(topic api.Topic) {
 	case api.TopicJob:
 		w.updateJobs()
 	case api.TopicAllocation:
-		w.updateAllocations()
+		{
+			w.updateAllocations()
+			w.updateJobs() // * Need this update, since we show allocation count in job view.
+		}
 	case api.TopicDeployment:
 		w.updateDeployments()
 	}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -94,8 +94,8 @@ func TestWatch_Happy(t *testing.T) {
 		// watcher.SubscribeHandler(models.HandleError, handleErr)
 
 		// Setup expectations
-		expectedJobsInitialCall := []*models.Job{{ID: "jupiter"}}
-		expectedJobsUpdated := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}}
+		expectedJobsInitialCall := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}}
+		expectedJobsUpdated := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}, {ID: "mars"}}
 
 		// callCount indicates how often the subscriber was notified
 		var callCount int
@@ -118,6 +118,11 @@ func TestWatch_Happy(t *testing.T) {
 		nomad.JobsReturnsOnCall(1, []*models.Job{
 			{ID: "jupiter"},
 			{ID: "saturn"},
+		}, nil)
+		nomad.JobsReturnsOnCall(2, []*models.Job{
+			{ID: "jupiter"},
+			{ID: "saturn"},
+			{ID: "mars"},
 		}, nil)
 
 		go watcher.Watch()
@@ -147,7 +152,7 @@ func TestWatch_Happy(t *testing.T) {
 
 		// Check that the call counts for each function haven't been called
 		// more often than expected.
-		r.Equal(nomad.JobsCallCount(), 2)
+		r.Equal(nomad.JobsCallCount(), 3)
 	})
 
 	t.Run("When a subscriber subscribes to a specific topic it doesn't get notified for other topics", func(t *testing.T) {
@@ -177,6 +182,7 @@ func TestWatch_Happy(t *testing.T) {
 
 		expectedJobs := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}}
 		nomad.JobsReturnsOnCall(1, expectedJobs, nil)
+		nomad.JobsReturnsOnCall(2, expectedJobs, nil)
 
 		go watcher.Watch()
 
@@ -216,7 +222,7 @@ func TestWatch_Happy(t *testing.T) {
 		nomad.StreamReturns(eventCh, nil)
 
 		// Declare what the the fake client should return on the different calls
-		nomad.JobsReturnsOnCall(1, []*models.Job{
+		nomad.JobsReturns([]*models.Job{
 			{ID: "jupiter"},
 			{ID: "saturn"},
 		}, nil)
@@ -254,7 +260,7 @@ func TestWatch_Happy(t *testing.T) {
 		r.Eventually(func() bool {
 			return nomad.AllocationsCallCount() == 2 &&
 				nomad.DeploymentsCallCount() == 2 &&
-				nomad.JobsCallCount() == 2
+				nomad.JobsCallCount() == 4
 		}, time.Second*5, time.Microsecond*5)
 
 		expectedJobs := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}}
@@ -347,8 +353,8 @@ func TestWatch_Happy(t *testing.T) {
 		watcher := watcher.NewWatcher(state, nomad, time.Second*2)
 
 		// Setup expectations
-		expectedJobsInitialCall := []*models.Job{{ID: "jupiter"}}
-		expectedJobsUpdateForced := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}}
+		expectedJobsInitialCall := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}}
+		expectedJobsUpdateForced := []*models.Job{{ID: "jupiter"}, {ID: "saturn"}, {ID: "mars"}}
 
 		// callCount indicates how often the subscriber was notified
 		var callCount int
@@ -371,6 +377,11 @@ func TestWatch_Happy(t *testing.T) {
 		nomad.JobsReturnsOnCall(1, []*models.Job{
 			{ID: "jupiter"},
 			{ID: "saturn"},
+		}, nil)
+		nomad.JobsReturnsOnCall(2, []*models.Job{
+			{ID: "jupiter"},
+			{ID: "saturn"},
+			{ID: "mars"},
 		}, nil)
 
 		go watcher.Watch()


### PR DESCRIPTION
### What is this about?

Show healthy and desired allocs count in job summary along with a status indicator.  (Follow up on #17)

**Example** : 2/3 ( 2 allocs are healthy out of 3 desired.)

The status indicator represents the below,

- ⚠️ Deployment cancelled/failed  
- ❌ Unhealthy allocs   
 - ✅ Deployment Success and Healthy  
- ⌛ Deployment Running  
- --- Pending    

### Preview

![damon-job-summary](https://user-images.githubusercontent.com/14835387/137252317-75d65a80-e451-4031-b170-337375250789.png)


