### PR TITLE
Add option to not quit Damon on fatal errors

### DIFF
--- a/component/error.go
+++ b/component/error.go
@@ -20,7 +20,7 @@ type ErrorProps struct {
 }
 
 func NewError() *Error {
-	buttons := []string{"Quit"}
+	buttons := []string{"Quit", "OK"}
 	modal := primitive.NewModal("Error", buttons, tcell.ColorDarkRed)
 
 	return &Error{

--- a/component/error_test.go
+++ b/component/error_test.go
@@ -33,7 +33,7 @@ func TestError_Happy(t *testing.T) {
 	actualDone := modal.SetDoneFuncArgsForCall(0)
 	text := modal.SetTextArgsForCall(0)
 
-	actualDone(0, "Quit")
+	actualDone(0, "buttonName")
 
 	r.True(doneCalled)
 	r.Equal(text, "error")

--- a/component/selections_test.go
+++ b/component/selections_test.go
@@ -59,7 +59,6 @@ func TestSelections_Sad(t *testing.T) {
 
 		selections := component.NewSelections(state)
 		selections.Namespace = dropdown
-		selections.Props.Rerender = func() {}
 
 		dropdown.PrimitiveReturns(tview.NewDropDown())
 

--- a/view/init.go
+++ b/view/init.go
@@ -130,7 +130,14 @@ func (v *View) Init(version string) {
 	// Error
 	v.components.Error.Bind(v.Layout.Pages)
 	v.components.Error.Props.Done = func(buttonIndex int, buttonLabel string) {
-		v.Layout.Container.Stop()
+		if buttonLabel == "Quit" {
+			v.Layout.Container.Stop()
+			return
+		}
+
+		v.Layout.Pages.RemovePage(component.PageNameError)
+		v.Layout.Container.SetFocus(v.state.Elements.TableMain)
+		v.GoBack()
 	}
 
 	// Info


### PR DESCRIPTION
This addresses #29 where fatal modals forced the user to quit the application. With this change the user can opt out and continue the application.

In a future PR, it is planned to check for specific errors on startup of Damon and try to handle specific error scenarios that could occur.