### PR TITLE
docker: update Go version to 1.19.1 to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # devbuild compiles the binary
 # -----------------------------------
-FROM golang:1.17 AS devbuild
+FROM golang:1.19.1 AS devbuild
 
 # Disable CGO to make sure we build static binaries
 ENV CGO_ENABLED=0


### PR DESCRIPTION
closes #42 