### PR TITLE
Feature/log pretty json

### DIFF
--- a/component/commands.go
+++ b/component/commands.go
@@ -24,7 +24,7 @@ var (
 	}
 
 	JobCommands = []string{
-		fmt.Sprintf("\n%sJob Commands:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%sJob Commands:", styles.HighlightSecondaryTag),
 		fmt.Sprintf("%s<Enter>%s to display allocations", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s<t>%s to display TaskGroups for the selected Job", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s<i>%s to display information for the selected Job", styles.HighlightPrimaryTag, styles.StandardColorTag),
@@ -43,7 +43,7 @@ var (
 	}
 
 	LogCommands = []string{
-		fmt.Sprintf("\n%sLog Commands:", styles.HighlightSecondaryTag),
+		fmt.Sprintf("%sLog Commands:", styles.HighlightSecondaryTag),
 		fmt.Sprintf("%s<Enter> | <ESC>%s to leave", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s</>%s apply filter", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s<h>%s highlight", styles.HighlightPrimaryTag, styles.StandardColorTag),
@@ -58,9 +58,11 @@ var (
 )
 
 type Commands struct {
-	TextView TextView
-	Props    *CommandsProps
-	slot     *tview.Flex
+	TextView     TextView
+	ViewTextView TextView
+	Props        *CommandsProps
+	slot         *tview.Flex
+	slotView     *tview.Flex
 }
 
 type CommandsProps struct {
@@ -70,7 +72,8 @@ type CommandsProps struct {
 
 func NewCommands() *Commands {
 	return &Commands{
-		TextView: primitive.NewTextView(tview.AlignLeft),
+		TextView:     primitive.NewTextView(tview.AlignLeft),
+		ViewTextView: primitive.NewTextView(tview.AlignLeft),
 		Props: &CommandsProps{
 			MainCommands: MainCommands,
 			ViewCommands: JobCommands,
@@ -92,15 +95,28 @@ func (c *Commands) Render() error {
 	c.updateText()
 
 	c.slot.AddItem(c.TextView.Primitive(), 0, 1, false)
+
+	if c.slotView != nil {
+		c.slotView.AddItem(c.ViewTextView.Primitive(), 0, 1, false)
+	}
+
 	return nil
 }
 
 func (c *Commands) updateText() {
-	commands := append(c.Props.MainCommands, c.Props.ViewCommands...)
-	cmds := strings.Join(commands, "\n")
-	c.TextView.SetText(cmds)
+	c.TextView.SetText(strings.Join(c.Props.MainCommands, "\n"))
+
+	if c.slotView != nil {
+		c.ViewTextView.SetText(strings.Join(c.Props.ViewCommands, "\n"))
+	}
 }
 
 func (c *Commands) Bind(slot *tview.Flex) {
 	c.slot = slot
+}
+
+// BindView binds the slot that displays the current view's context-specific
+// commands, rendered to the right of the main Commands box.
+func (c *Commands) BindView(slot *tview.Flex) {
+	c.slotView = slot
 }

--- a/component/commands.go
+++ b/component/commands.go
@@ -71,14 +71,28 @@ type CommandsProps struct {
 }
 
 func NewCommands() *Commands {
+	textView := primitive.NewTextView(tview.AlignLeft)
+	textView.ModifyPrimitive(disableWrap)
+
+	viewTextView := primitive.NewTextView(tview.AlignLeft)
+	viewTextView.ModifyPrimitive(disableWrap)
+
 	return &Commands{
-		TextView:     primitive.NewTextView(tview.AlignLeft),
-		ViewTextView: primitive.NewTextView(tview.AlignLeft),
+		TextView:     textView,
+		ViewTextView: viewTextView,
 		Props: &CommandsProps{
 			MainCommands: MainCommands,
 			ViewCommands: JobCommands,
 		},
 	}
+}
+
+// disableWrap keeps each command on a single row: on a narrow terminal a
+// wrapped line pushes every entry below it down, which can shove later
+// commands past the header's visible height entirely. Truncating a long
+// line is preferable to losing whole entries off-screen.
+func disableWrap(t *tview.TextView) {
+	t.SetWrap(false)
 }
 
 func (c *Commands) Update(commands []string) {

--- a/component/commands.go
+++ b/component/commands.go
@@ -49,6 +49,7 @@ var (
 		fmt.Sprintf("%s<h>%s highlight", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s<s>%s stop log stream", styles.HighlightPrimaryTag, styles.StandardColorTag),
 		fmt.Sprintf("%s<r>%s resume log stream", styles.HighlightPrimaryTag, styles.StandardColorTag),
+		fmt.Sprintf("%s<p>%s pretty-print JSON lines", styles.HighlightPrimaryTag, styles.StandardColorTag),
 	}
 
 	DeploymentCommands = []string{}

--- a/component/commands_test.go
+++ b/component/commands_test.go
@@ -18,18 +18,24 @@ func TestCommands_Happy(t *testing.T) {
 	r := require.New(t)
 
 	textView := &componentfakes.FakeTextView{}
+	viewTextView := &componentfakes.FakeTextView{}
 	cmds := component.NewCommands()
 	cmds.TextView = textView
+	cmds.ViewTextView = viewTextView
 	cmds.Props.MainCommands = []string{"command1", "command2"}
 	cmds.Props.ViewCommands = []string{"subCmd1", "subCmd2"}
 
 	cmds.Bind(tview.NewFlex())
+	cmds.BindView(tview.NewFlex())
 
 	err := cmds.Render()
 	r.NoError(err)
 
 	text := textView.SetTextArgsForCall(0)
-	r.Equal(text, "command1\ncommand2\nsubCmd1\nsubCmd2")
+	r.Equal(text, "command1\ncommand2")
+
+	viewText := viewTextView.SetTextArgsForCall(0)
+	r.Equal(viewText, "subCmd1\nsubCmd2")
 }
 
 func TestCommands_Sad(t *testing.T) {

--- a/component/logs.go
+++ b/component/logs.go
@@ -5,6 +5,7 @@ package component
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -35,6 +36,7 @@ type LogStreamProps struct {
 	ChangedFunc       func()
 	TaskName          string
 	App               *tview.Application
+	PrettyJSON        bool
 }
 
 func NewLogger() *Logger {
@@ -81,7 +83,15 @@ func (l *Logger) Render() error {
 		l.Props.Data = bytes.Join(lines, []byte("\n"))
 	}
 
-	display := filter(l.Props.Data, l.Props.Filter)
+	data := l.Props.Data
+	if l.Props.PrettyJSON {
+		// Pretty-printing turns 1 raw line into N display lines, so filter()'s
+		// per-line regex may then only match a sub-line of a JSON block rather
+		// than the whole entry. Acceptable known limitation for now.
+		data = prettifyJSONLines(data)
+	}
+
+	display := filter(data, l.Props.Filter)
 
 	if l.Props.Filter == "" {
 		display = highlight(display, l.Props.Highlight)
@@ -153,6 +163,26 @@ func filter(logs []byte, filter string) []byte {
 		}
 	}
 	return result
+}
+
+// prettifyJSONLines indents any line that parses as valid JSON, leaving
+// non-JSON lines untouched.
+func prettifyJSONLines(logs []byte) []byte {
+	lines := bytes.Split(logs, []byte("\n"))
+	out := make([][]byte, 0, len(lines))
+
+	for _, line := range lines {
+		if json.Valid(line) {
+			var buf bytes.Buffer
+			if err := json.Indent(&buf, line, "", "  "); err == nil {
+				out = append(out, buf.Bytes())
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+
+	return bytes.Join(out, []byte("\n"))
 }
 
 func highlight(logs []byte, highlight string) []byte {

--- a/component/logs_test.go
+++ b/component/logs_test.go
@@ -34,6 +34,25 @@ func TestLogs_Happy(t *testing.T) {
 		r.Equal(string(text), "logs")
 	})
 
+	t.Run("When PrettyJSON is enabled", func(t *testing.T) {
+		textView := &componentfakes.FakeTextView{}
+		logs := component.NewLogger()
+		logs.TextView = textView
+		logs.Props.HandleNoResources = func(format string, args ...interface{}) {}
+		logs.Props.PrettyJSON = true
+		logs.Props.Data = []byte(`plain text line
+{"foo":"bar","n":1}
+not json {at all`)
+
+		logs.Bind(tview.NewFlex())
+
+		err := logs.Render()
+		r.NoError(err)
+
+		text := textView.SetTextArgsForCall(0)
+		r.Equal("plain text line\n{\n  \"foo\": \"bar\",\n  \"n\": 1\n}\nnot json {at all", string(text))
+	})
+
 	t.Run("When there is no data to render", func(t *testing.T) {
 		textView := &componentfakes.FakeTextView{}
 		logs := component.NewLogger()

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -29,9 +29,10 @@ type Elements struct {
 }
 
 type Header struct {
-	SlotInfo *tview.Flex
-	SlotCmd  *tview.Flex
-	SlotLogo *tview.Flex
+	SlotInfo    *tview.Flex
+	SlotCmd     *tview.Flex
+	SlotViewCmd *tview.Flex
+	SlotLogo    *tview.Flex
 }
 
 func EnableMouse(l *Layout) {
@@ -60,11 +61,13 @@ func Default(l *Layout) {
 	l.Header.SlotInfo.AddItem(l.Elements.Dropdowns, 0, 1, false)
 
 	l.Header.SlotCmd = tview.NewFlex()
+	l.Header.SlotViewCmd = tview.NewFlex()
 	l.Header.SlotLogo = tview.NewFlex()
 
 	header := tview.NewFlex().
 		AddItem(l.Header.SlotInfo, 0, 1, false).
 		AddItem(l.Header.SlotCmd, 0, 1, false).
+		AddItem(l.Header.SlotViewCmd, 0, 1, false).
 		AddItem(l.Header.SlotLogo, 0, 1, false)
 
 	header.SetBorderPadding(1, 1, 2, 2)

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -66,8 +66,8 @@ func Default(l *Layout) {
 
 	header := tview.NewFlex().
 		AddItem(l.Header.SlotInfo, 0, 1, false).
-		AddItem(l.Header.SlotCmd, 0, 1, false).
-		AddItem(l.Header.SlotViewCmd, 0, 1, false).
+		AddItem(l.Header.SlotCmd, 0, 2, false).
+		AddItem(l.Header.SlotViewCmd, 0, 2, false).
 		AddItem(l.Header.SlotLogo, 0, 1, false)
 
 	header.SetBorderPadding(1, 1, 2, 2)
@@ -77,7 +77,7 @@ func Default(l *Layout) {
 
 	mainPage := tview.NewFlex().SetDirection(tview.FlexRow)
 	mainPage.
-		AddItem(header, 0, 4, false).
+		AddItem(header, 10, 0, false).
 		AddItem(body, 0, 12, false).
 		AddItem(footer, 0, 0, false)
 

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -32,6 +32,9 @@ func TestDefaultLayout(t *testing.T) {
 	r.NotNil(l.Header.SlotCmd)
 	r.IsType(l.Header.SlotCmd, &tview.Flex{})
 
+	r.NotNil(l.Header.SlotViewCmd)
+	r.IsType(l.Header.SlotViewCmd, &tview.Flex{})
+
 	r.NotNil(l.Header.SlotLogo)
 	r.IsType(l.Header.SlotLogo, &tview.Flex{})
 

--- a/state/state.go
+++ b/state/state.go
@@ -50,6 +50,7 @@ type Toggle struct {
 	Search       bool
 	LogSearch    bool
 	LogHighlight bool
+	PrettyJSON   bool
 }
 
 type Elements struct {

--- a/view/init.go
+++ b/view/init.go
@@ -162,6 +162,7 @@ func (v *View) Init(version string) {
 
 	// Commands
 	v.components.Commands.Bind(v.Layout.Header.SlotCmd)
+	v.components.Commands.BindView(v.Layout.Header.SlotViewCmd)
 	v.components.Commands.Render()
 
 	// Selections

--- a/view/init.go
+++ b/view/init.go
@@ -50,6 +50,8 @@ func (v *View) Init(version string) {
 	v.components.LogSearch.Props.ChangedFunc = func(text string) {
 		v.state.Filter.Logs = text
 		v.components.LogStream.Props.Filter = text
+		v.components.LogStream.Render()
+		v.Draw()
 	}
 
 	v.components.LogSearch.Props.DoneFunc = func(key tcell.Key) {
@@ -66,6 +68,8 @@ func (v *View) Init(version string) {
 	v.components.LogHighlight.Bind(v.Layout.Footer)
 	v.components.LogHighlight.Props.ChangedFunc = func(text string) {
 		v.components.LogStream.Props.Highlight = text
+		v.components.LogStream.Render()
+		v.Draw()
 	}
 
 	v.components.LogHighlight.Props.DoneFunc = func(key tcell.Key) {

--- a/view/inputs.go
+++ b/view/inputs.go
@@ -114,6 +114,13 @@ func (v *View) InputLogs(event *tcell.EventKey) *tcell.EventKey {
 				v.Watcher.ResumeLogs()
 
 			}
+		case 'p':
+			if !v.Layout.Footer.HasFocus() {
+				v.state.Toggle.PrettyJSON = !v.state.Toggle.PrettyJSON
+				v.components.LogStream.Props.PrettyJSON = v.state.Toggle.PrettyJSON
+				v.components.LogStream.Render()
+				v.Draw()
+			}
 		}
 	}
 

--- a/view/logs.go
+++ b/view/logs.go
@@ -17,6 +17,7 @@ func (v *View) Logs(taskName string, allocID, source string) {
 
 	logStreamProps := v.components.LogStream.Props
 	logStreamProps.TaskName = taskName
+	logStreamProps.PrettyJSON = v.state.Toggle.PrettyJSON
 
 	// If the logstream contains data from a previous log stream
 	// remove it!


### PR DESCRIPTION
Architect: Joachim "jriberg" Friberg — this change was designed and directed by Joachim, who scoped the feature, drove the UX decisions, and found/tested the follow-up fixes below against a live Nomad cluster. Implementation was carried out with Claude Code under his direction.

Adds a JSON pretty-print toggle to the log viewer: press p while viewing logs to indent any line that parses as valid JSON, press again to revert. Non-JSON lines are left untouched.

While testing this feature, a few pre-existing UX issues in the log viewer's header and search/highlight fields surfaced and are fixed here too:
- The header's "Commands" box is now split into two side-by-side boxes — general commands on the left, the current view's commands (e.g. "Log Commands", including the new p binding) on the right — instead of one long stacked list.
- Command hint text no longer wraps and pushes later entries off-screen at common terminal widths (80–100 cols) — this was hiding the p entry entirely on non-wide terminals.
- Log search (/) and highlight (h) now re-render live as you type, instead of only updating on the next streamed log line — previously this made highlighting look delayed by several seconds and filtering look like it silently did nothing.

What changed

- component/logs.go: new prettifyJSONLines helper — for each log line, json.Valid + json.Indent indent it if it's valid JSON, otherwise pass through unchanged. Applied before existing filter/highlight processing.
- view/inputs.go: new p keybinding in the log viewer, toggling state.Toggle.PrettyJSON.
- state/state.go: added PrettyJSON toggle field.
- layout/layout.go: added a dedicated header slot (SlotViewCmd) and widened the two command boxes relative to the info/logo boxes; gave the header a fixed row height instead of a proportional one.
- component/commands.go: Commands now renders the general and view-specific command lists in two independent text views instead of one concatenated block; disabled text wrapping on both so long lines truncate instead of wrapping onto extra rows and pushing later entries out of view.
- view/init.go: wired the new header slot; LogSearch/LogHighlight ChangedFunc callbacks now re-render and redraw the log stream on every keystroke.

Testing

- go build ./..., go vet ./..., go test ./... all pass.
- Added/updated unit tests: component/logs_test.go, component/commands_test.go, layout/layout_test.go.
- Verified with a simulated-screen render test at 60/80/100/140 column widths that every command entry (including p) stays visible and side-by-side rather than wrapping off-screen.
- Manually verified against a local nomad agent -dev with a docker-driver job: pretty-print toggling, live filter/highlight as you type, and header layout at different terminal sizes.